### PR TITLE
Fix galaxy

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -41,5 +41,15 @@ jobs:
       - name: Run molecule
         run: molecule test -s "${{ matrix.scenario }}"
 
-# notifications:
-#   webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  publish:
+    name: Galaxy
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: galaxy
+        uses: ansible-actions/ansible-galaxy-action@v1.2.0
+        with:
+          galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
+          galaxy_version: ${{  github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Docker Tools
 ============
 
-[![Build Status](https://travis-ci.org/ome/ansible-role-docker-tools.svg)](https://travis-ci.org/ome/ansible-role-docker-tools)
-[![Ansible Role](https://img.shields.io/ansible/role/41997.svg)](https://galaxy.ansible.com/ome/docker_tools/)
+[![Actions Status](https://github.com/ome/ansible-role-logrotate/workflows/Molecule/badge.svg)](https://github.com/ome/ansible-role-docker-tools/actions)
+[![Ansible Role](https://img.shields.io/badge/ansible--galaxy-docker_tools-blue.svg)](https://galaxy.ansible.com/ui/standalone/roles/ome/docker_tools/)
 
 Install Python based docker tools, such as `docker-compose`.
 


### PR DESCRIPTION
The paragraph from ``.github/workflow/molecule.yml`` dealing with Galaxy release is completely missing. Although I have tagged, the GHA did not run the release job. 

This PR is:

- fixing the Galaxy release problem (see screenshot below, now the "Galaxy" job is there too, but it is missing in the present GHA actions without this PR)
- Also fixing the badges in README here. The present badge is pointing to travis...

To decide:
As [the 1.1.0 tag](https://github.com/ome/ansible-role-docker-tools/releases/tag/1.1.0) has been already pushed (with no publishing effect), I can see two options:

1. **delete [the 1.1.0 tag](https://github.com/ome/ansible-role-docker-tools/releases/tag/1.1.0)**  and create a new one after this PR is merged, also called 1.1.0, which will, hopefully, kick on the release process or
2. Do not delete the 1.1.0 tag, instead, create a new, 1.1.1 tag (which will kick on the release process etc.).

Which one of the two options above would you prefer @khaledk2 @jburel ?

<img width="485" height="230" alt="Screenshot 2025-10-31 at 11 25 40" src="https://github.com/user-attachments/assets/6ce222b6-c627-4615-b5c1-6e67ea3eac60" />

